### PR TITLE
When adding a word, using an np.ndarray instead of a list

### DIFF
--- a/notebooks/introductory/Part_3_1_Building_a_Concept_Database_and_Vocabulary.ipynb
+++ b/notebooks/introductory/Part_3_1_Building_a_Concept_Database_and_Vocabulary.ipynb
@@ -583,7 +583,7 @@
    ],
    "source": [
     "# If you want to add words manually (one by one) use:\n",
-    "vocab.add_word(\"test\", cnt=31, vec=[1.42, 1.44, 1.55], replace=True)\n",
+    "vocab.add_word(\"test\", cnt=31, vec=np.array([1.42, 1.44, 1.55]), replace=True)\n",
     "vocab.vocab.keys()"
    ]
   },


### PR DESCRIPTION
Previously, the vector was added as a `list`. However, the `add_word` method expects a `np.ndarray`.

While this does not cause problems within this part of the tutorial, if one were to use something that calls `vector_context_model.get_context_vectors` (e.g `train`, `train_supervised`), this method can raise an exception when an attempt is made to multiply this `list` with its weight (a `float`).