### PR TITLE
CU-8692zn14d: Add missing seaborn installs where necessary

### DIFF
--- a/notebooks/introductory/Part_3_2_Extracting_Diseases_from_Electronic_Health_Records.html
+++ b/notebooks/introductory/Part_3_2_Extracting_Diseases_from_Electronic_Health_Records.html
@@ -13093,6 +13093,8 @@ div#notebook {
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="c1"># Install medcat</span>
 <span class="o">!</span> pip install <span class="nv">medcat</span><span class="o">==</span><span class="m">1</span>.8.0
+<span class="c1"># install seaborn</span>
+<span class="o">!</span> pip install seaborn
 <span class="k">try</span><span class="p">:</span>
     <span class="kn">from</span> <span class="nn">medcat.cat</span> <span class="kn">import</span> <span class="n">CAT</span>
 <span class="k">except</span><span class="p">:</span>
@@ -14696,10 +14698,10 @@ INFO:medcat:Annotated until now: 1072 docs; Current BS: 16 docs; Elapsed time: 9
 
  
  
-<div id="0094648e-a82e-4595-9eed-f4245837575a"></div>
+<div id="904bd220-1e4d-4621-98a2-ca81be354c65"></div>
 <div class="output_subarea output_widget_view ">
 <script type="text/javascript">
-var element = $('#0094648e-a82e-4595-9eed-f4245837575a');
+var element = $('#904bd220-1e4d-4621-98a2-ca81be354c65');
 </script>
 <script type="application/vnd.jupyter.widget-view+json">
 {"model_id": "05b18c97da9d4d05b9280df006a5fb82", "version_major": 2, "version_minor": 0}

--- a/notebooks/introductory/Part_3_2_Extracting_Diseases_from_Electronic_Health_Records.ipynb
+++ b/notebooks/introductory/Part_3_2_Extracting_Diseases_from_Electronic_Health_Records.ipynb
@@ -276,6 +276,8 @@
    "source": [
     "# Install medcat\n",
     "! pip install medcat==1.8.0\n",
+    "# install seaborn\n",
+    "! pip install seaborn\n",
     "try:\n",
     "    from medcat.cat import CAT\n",
     "except:\n",

--- a/notebooks/introductory/Part_4_3_Annotating_documents_with_the_full_MedCAT_pipeline_with_MetaAnnotations.html
+++ b/notebooks/introductory/Part_4_3_Annotating_documents_with_the_full_MedCAT_pipeline_with_MetaAnnotations.html
@@ -13086,6 +13086,8 @@ div#notebook {
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="c1"># Install medcat</span>
 <span class="o">!</span> pip install <span class="nv">medcat</span><span class="o">==</span><span class="m">1</span>.8.0
+<span class="c1"># install seaborn</span>
+<span class="o">!</span> pip install seaborn
 <span class="k">try</span><span class="p">:</span>
     <span class="kn">from</span> <span class="nn">medcat.cat</span> <span class="kn">import</span> <span class="n">CAT</span>
 <span class="k">except</span><span class="p">:</span>

--- a/notebooks/introductory/Part_4_3_Annotating_documents_with_the_full_MedCAT_pipeline_with_MetaAnnotations.ipynb
+++ b/notebooks/introductory/Part_4_3_Annotating_documents_with_the_full_MedCAT_pipeline_with_MetaAnnotations.ipynb
@@ -266,6 +266,8 @@
    "source": [
     "# Install medcat\n",
     "! pip install medcat==1.8.0\n",
+    "# install seaborn\n",
+    "! pip install seaborn\n",
     "try:\n",
     "    from medcat.cat import CAT\n",
     "except:\n",

--- a/notebooks/introductory/Part_5_Prevalence_of_Physical_and_Mental_Diseases.html
+++ b/notebooks/introductory/Part_5_Prevalence_of_Physical_and_Mental_Diseases.html
@@ -13086,6 +13086,8 @@ div#notebook {
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="c1"># Install medcat</span>
 <span class="o">!</span> pip install <span class="nv">medcat</span><span class="o">==</span><span class="m">1</span>.8.0
+<span class="c1"># install seaborn</span>
+<span class="o">!</span> pip install seaborn
 <span class="k">try</span><span class="p">:</span>
     <span class="kn">from</span> <span class="nn">medcat.cat</span> <span class="kn">import</span> <span class="n">CAT</span>
 <span class="k">except</span><span class="p">:</span>

--- a/notebooks/introductory/Part_5_Prevalence_of_Physical_and_Mental_Diseases.ipynb
+++ b/notebooks/introductory/Part_5_Prevalence_of_Physical_and_Mental_Diseases.ipynb
@@ -266,6 +266,8 @@
    "source": [
     "# Install medcat\n",
     "! pip install medcat==1.8.0\n",
+    "# install seaborn\n",
+    "! pip install seaborn\n",
     "try:\n",
     "    from medcat.cat import CAT\n",
     "except:\n",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-xdist~=2.5.0
 nbmake<1.4
 nbconvert<6
 jinja2<=3.0
+seaborn


### PR DESCRIPTION
Parts 3.2, 4.3, and 5 used `seaborn`, but it was not installed nor is it a requirement for `medcat`.

So added the install where appropriate, alongside adding it to `requirements-dev.txt`.

Thanks to @mkorvas for pointing out the issue.

PS:
It's odd that the smoketests didnt _smoke out_ this issue, though.